### PR TITLE
Remove #wikimedia-toolserver from list of tracked IRC channels

### DIFF
--- a/irc_channels.conf
+++ b/irc_channels.conf
@@ -3,7 +3,6 @@ mediawiki
 wikimedia-dev
 wikimedia-labs
 wikimedia-mobile
-wikimedia-toolserver
 wikimedia-tech
 wikimedia-analytics
 wikimedia-fundraising


### PR DESCRIPTION
Toolserver itself is dead and has been replaced by Tool Labs so
that channel is rather irrelevant today for us.
