### PR TITLE
Exclude unmaintained BayesianFilter extension from Gerrit statistics

### DIFF
--- a/gerrit_trackers_blacklist.conf
+++ b/gerrit_trackers_blacklist.conf
@@ -15,6 +15,7 @@ integration/zuul
 labs/incubator
 mediawiki/extensions/AccessibilitySimulation
 mediawiki/extensions/Agora
+mediawiki/extensions/BayesianFilter
 mediawiki/extensions/BlameMaps
 mediawiki/extensions/ClickTracking
 mediawiki/extensions/ContributionReporting


### PR DESCRIPTION
https://phabricator.wikimedia.org/T118460
